### PR TITLE
setting frame_id as argument in Navigator

### DIFF
--- a/src/navigator/Navigator.js
+++ b/src/navigator/Navigator.js
@@ -28,6 +28,7 @@ NAV2D.Navigator = function(options) {
   var robot_pose = options.robot_pose || '/robot_pose';
   var serverName = options.serverName || '/move_base';
   var actionName = options.actionName || 'move_base_msgs/MoveBaseAction';
+  var frame_id = options.frame_id || '/map';
   var withOrientation = options.withOrientation || false;
   var use_image = options.image;
   this.rootObject = options.rootObject || new createjs.Container();
@@ -55,7 +56,7 @@ NAV2D.Navigator = function(options) {
       goalMessage : {
         target_pose : {
           header : {
-            frame_id : '/map'
+            frame_id : frame_id,
           },
           pose : pose
         }

--- a/src/navigator/OccupancyGridClientNav.js
+++ b/src/navigator/OccupancyGridClientNav.js
@@ -30,6 +30,7 @@ NAV2D.OccupancyGridClientNav = function(options) {
   var continuous = options.continuous;
   var serverName = options.serverName || '/move_base';
   var actionName = options.actionName || 'move_base_msgs/MoveBaseAction';
+  var frame_id = options.frame_id || '/map';
   var rootObject = options.rootObject || new createjs.Container();
   var viewer = options.viewer;
   var withOrientation = options.withOrientation || false;
@@ -49,6 +50,7 @@ NAV2D.OccupancyGridClientNav = function(options) {
     tfClient: tfClient,
     serverName: serverName,
     actionName: actionName,
+    frame_id: frame_id,
     robot_pose : robot_pose,
     rootObject: rootObject,
     withOrientation: withOrientation,


### PR DESCRIPTION
I met a problem with my robot as follows:

```
Warning: Invalid argument "/map" passed to canTransform argument source_frame in tf2 frame_ids cannot start with a '/' like: 
         at line 134 in /tmp/binarydeb/ros-kinetic-tf2-0.5.17/src/buffer_core.cpp
```
It is caused from the `frame_id` of goal pose, is hard-coded in Navigator.
Additionally, I would like to change `frame_id` for map having another frame_id.
This pull request will add `frame_id` option to Navigator,
user can change the `frame_id` of goal pose.
