### PR TITLE
Resolve false marker scaling

### DIFF
--- a/src/navigator/Navigator.js
+++ b/src/navigator/Navigator.js
@@ -138,7 +138,7 @@ NAV2D.Navigator = function(options) {
     // update the robots position on the map
     robotMarker.x = pose.x;
     robotMarker.y = -pose.y;
-    if (!initScaleSet) {
+    if (!initScaleSet && stage.scaleX>1 && stage.scaleY>1) {
       robotMarker.scaleX = 1.0 / stage.scaleX;
       robotMarker.scaleY = 1.0 / stage.scaleY;
       initScaleSet = true;


### PR DESCRIPTION
The size of the arrow marker on the map is occasionally falsely scaled. Added a few requirement in the IF statement to prevent it from false scaling.